### PR TITLE
Fix API key assignment from environment variable

### DIFF
--- a/Application/Models/Settings/OpenAiSettings.cs
+++ b/Application/Models/Settings/OpenAiSettings.cs
@@ -7,7 +7,7 @@ public class OpenAiSettings
     public OpenAiSettings(string apiKey)
     {
         var environmentApiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
-        if (string.IsNullOrWhiteSpace(environmentApiKey))
+        if (!string.IsNullOrWhiteSpace(environmentApiKey))
         {
             // try to get the connection string from environment variables
             apiKey = environmentApiKey;


### PR DESCRIPTION
Corrects the logic to use the API key from environment variables when it is not empty or whitespace. This ensures proper fallback behavior and prevents overwriting valid keys.